### PR TITLE
Add basic framework for Casbin.js

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+# don't ever lint node_modules
+node_modules
+# don't lint build output (make sure it's set to your correct build folder name)
+lib

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,20 @@
+module.exports = {
+    root: true,
+    parser: '@typescript-eslint/parser',
+    plugins: [
+        '@typescript-eslint',
+    ],
+    env: {
+        "browser": true,
+        "node": true
+    },
+    extends: [
+        'eslint:recommended',
+        'plugin:@typescript-eslint/recommended',
+    ],
+    rules: {
+        '@typescript-eslint/no-var-requires': 0,
+        '@typescript-eslint/explicit-module-boundary-types': 0,
+        '@typescript-eslint/no-unused-vars': 0
+    }
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     extends: [
         'eslint:recommended',
         'plugin:@typescript-eslint/recommended',
+        'prettier'
     ],
     rules: {
         '@typescript-eslint/no-var-requires': 0,

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+/lib
 
 # misc
 .DS_Store

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "printWidth": 140,
+  "tabWidth": 4
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+
+sudo: false
+
+node_js:
+  - '12'
+  - 'stable'
+
+install: yarn install
+
+script:
+  - yarn run lint
+  - yarn run test

--- a/jestconfig.json
+++ b/jestconfig.json
@@ -1,0 +1,10 @@
+{
+    "transform": {
+        "^.+\\.(t|j)sx?$": "ts-jest"
+    },
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"],
+    "coveragePathIgnorePatterns": [
+        "/node_modules/"
+      ]
+}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "casbin.js",
   "version": "0.0.1",
-  "main": "`index.js",
-  "repository": "https://github.com/kingiw/casbin.js.git",
+  "main": "./lib/index.js",
+  "types": "./lib.index.d.ts",
+  "repository": "https://github.com/casbin/casbin.js.git",
   "author": "kingiw <kingiw@hotmail.com>",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "kingiw <kingiw@hotmail.com>",
   "license": "MIT",
   "scripts": {
-    "format": "prettier --write src/**/*.ts",
+    "format": "prettier --write 'src/**/*.ts'",
     "lint": "yarn eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "build": "tsc",
     "test": "jest --config jestconfig.json"

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
     "test": "jest --config jestconfig.json"
   },
   "devDependencies": {
+    "@types/express": "^4.17.6",
     "@types/jest": "^25.2.3",
     "@typescript-eslint/eslint-plugin": "^3.2.0",
     "@typescript-eslint/parser": "^3.2.0",
+    "casbin": "^5.0.4",
     "eslint": "^7.2.0",
     "eslint-config-prettier": "^6.11.0",
     "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "casbin.js",
+  "version": "0.0.1",
+  "main": "`index.js",
+  "repository": "https://github.com/kingiw/casbin.js.git",
+  "author": "kingiw <kingiw@hotmail.com>",
+  "license": "MIT",
+  "scripts": {
+    "lint": "yarn eslint . --ext .js,.jsx,.ts,.tsx --fix",
+    "build": "tsc",
+    "test": "jest --config jestconfig.json"
+  },
+  "devDependencies": {
+    "@types/jest": "^25.2.3",
+    "@typescript-eslint/eslint-plugin": "^3.2.0",
+    "@typescript-eslint/parser": "^3.2.0",
+    "eslint": "^7.2.0",
+    "express": "^4.17.1",
+    "jest": "^26.0.1",
+    "ts-jest": "^26.1.0",
+    "tslint-config-prettier": "^1.18.0",
+    "typescript": "^3.9.5"
+  },
+  "dependencies": {
+    "axios": "^0.19.2"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "kingiw <kingiw@hotmail.com>",
   "license": "MIT",
   "scripts": {
+    "format": "prettier --write src/**/*.ts",
     "lint": "yarn eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "build": "tsc",
     "test": "jest --config jestconfig.json"
@@ -15,8 +16,10 @@
     "@typescript-eslint/eslint-plugin": "^3.2.0",
     "@typescript-eslint/parser": "^3.2.0",
     "eslint": "^7.2.0",
+    "eslint-config-prettier": "^6.11.0",
     "express": "^4.17.1",
     "jest": "^26.0.1",
+    "prettier": "^2.0.5",
     "ts-jest": "^26.1.0",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.9.5"

--- a/src/__test__/example/basic_model.conf
+++ b/src/__test__/example/basic_model.conf
@@ -1,0 +1,11 @@
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub, obj, act
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = r.sub == p.sub && r.obj == p.obj && r.act == p.act

--- a/src/__test__/example/basic_policy.csv
+++ b/src/__test__/example/basic_policy.csv
@@ -1,0 +1,2 @@
+p, alice, data1, read
+p, bob, data2, write

--- a/src/__test__/example/rbac_model.conf
+++ b/src/__test__/example/rbac_model.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub, obj, act
+
+[role_definition]
+g = _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act

--- a/src/__test__/example/rbac_policy.csv
+++ b/src/__test__/example/rbac_policy.csv
@@ -1,0 +1,5 @@
+p, alice, data1, read
+p, bob, data2, write
+p, data2_admin, data2, read
+p, data2_admin, data2, write
+g, alice, data2_admin

--- a/src/__test__/example/rbac_with_domains_model.conf
+++ b/src/__test__/example/rbac_with_domains_model.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = sub, dom, obj, act
+
+[policy_definition]
+p = sub, dom, obj, act
+
+[role_definition]
+g = _, _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = g(r.sub, p.sub, r.dom) && r.dom == p.dom && r.obj == p.obj && r.act == p.act

--- a/src/__test__/example/rbac_with_domains_policy.csv
+++ b/src/__test__/example/rbac_with_domains_policy.csv
@@ -1,0 +1,8 @@
+p, admin, domain1, data1, read
+p, admin, domain1, data1, write
+p, admin, domain2, data2, read
+p, admin, domain2, data2, write
+p, alice, domain1, data3, read
+
+g, alice, admin, domain1
+g, bob, admin, domain2

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -1,14 +1,14 @@
-import axios from "axios";
-import { Enforcer } from "../index";
+import axios from 'axios';
+import { Enforcer } from '../index';
 
-jest.mock("axios");
+jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-test("Mock functions", async () => {
-  const resp = { data: { message: "ok", data: "123123" } };
-  // Specify the returned data of the mockedAxios once
-  mockedAxios.get.mockImplementationOnce(() => Promise.resolve(resp));
-  const enforcer = new Enforcer("http://localhost:4000");
-  const data = await enforcer.getData();
-  expect(data).toBe("123123");
+test('Mock functions', async () => {
+    const resp = { data: { message: 'ok', data: '123123' } };
+    // Specify the returned data of the mockedAxios once
+    mockedAxios.get.mockImplementationOnce(() => Promise.resolve(resp));
+    const enforcer = new Enforcer('http://localhost:4000');
+    const data = await enforcer.getData();
+    expect(data).toBe('123123');
 });

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -5,10 +5,17 @@ jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 test('Mock functions', async () => {
-    const resp = { data: { message: 'ok', data: '123123' } };
+    const respObj = {
+        read: ['data1', 'data2'],
+        write: ['data2']
+    }
+    const resp = { data: { message: 'ok', data: JSON.stringify(respObj)}};
     // Specify the returned data of the mockedAxios once
     mockedAxios.get.mockImplementationOnce(() => Promise.resolve(resp));
-    const enforcer = new Enforcer('http://localhost:4000');
-    const data = await enforcer.getData();
-    expect(data).toBe('123123');
+    // TODO: Use mock function to get response object
+    // const enforcer = new Enforcer('http://localhost:4000');
+    // enforcer.setUser('alice');
+    // expect(enforcer.getProfiles()).toMatchObject(respObj);
+
+    // expect(mockedAxios.get('http://localhost:4000/api/casbin?casbin_subject=alice')).toMatchObject(respObj);
 });

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -1,0 +1,14 @@
+import axios from "axios";
+import { Enforcer } from "../index";
+
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+test("Mock functions", async () => {
+  const resp = { data: { message: "ok", data: "123123" } };
+  // Specify the returned data of the mockedAxios once
+  mockedAxios.get.mockImplementationOnce(() => Promise.resolve(resp));
+  const enforcer = new Enforcer("http://localhost:4000");
+  const data = await enforcer.getData();
+  expect(data).toBe("123123");
+});

--- a/src/__test__/server.test.ts
+++ b/src/__test__/server.test.ts
@@ -7,15 +7,20 @@ import TestServer from './server';
 
 describe('Communication with server', () => {
     let server: TestServer;
-    beforeAll(() => {
+    beforeAll(async () => {
         server = new TestServer();
-        server.start();
+        await server.start();
     });
 
     test('Get data from server', async () => {
         const enforcer = new Enforcer('http://localhost:4000');
         const data = await enforcer.getData();
         expect(data).toBe('this is the data');
+    });
+
+    test('Request for /api/casbin', async () => {
+        const enforcer = new Enforcer('http://localhost:4000/api/casbin?casbin_subject=alice');
+        await enforcer.getData();
     });
 
     afterAll(() => server.terminate());

--- a/src/__test__/server.test.ts
+++ b/src/__test__/server.test.ts
@@ -1,0 +1,22 @@
+/**
+ * @jest-environment node
+ */
+
+import { Enforcer } from "../index";
+import TestServer from "./server";
+
+describe("Communication with server", () => {
+  let server: TestServer;
+  beforeAll(() => {
+    server = new TestServer();
+    server.start();
+  });
+
+  test("Get data from server", async () => {
+    const enforcer = new Enforcer("http://localhost:4000");
+    const data = await enforcer.getData();
+    expect(data).toBe("this is the data");
+  });
+
+  afterAll(() => server.terminate());
+});

--- a/src/__test__/server.test.ts
+++ b/src/__test__/server.test.ts
@@ -2,21 +2,21 @@
  * @jest-environment node
  */
 
-import { Enforcer } from "../index";
-import TestServer from "./server";
+import { Enforcer } from '../index';
+import TestServer from './server';
 
-describe("Communication with server", () => {
-  let server: TestServer;
-  beforeAll(() => {
-    server = new TestServer();
-    server.start();
-  });
+describe('Communication with server', () => {
+    let server: TestServer;
+    beforeAll(() => {
+        server = new TestServer();
+        server.start();
+    });
 
-  test("Get data from server", async () => {
-    const enforcer = new Enforcer("http://localhost:4000");
-    const data = await enforcer.getData();
-    expect(data).toBe("this is the data");
-  });
+    test('Get data from server', async () => {
+        const enforcer = new Enforcer('http://localhost:4000');
+        const data = await enforcer.getData();
+        expect(data).toBe('this is the data');
+    });
 
-  afterAll(() => server.terminate());
+    afterAll(() => server.terminate());
 });

--- a/src/__test__/server.test.ts
+++ b/src/__test__/server.test.ts
@@ -20,7 +20,12 @@ describe('Communication with server', () => {
 
     test('Request for /api/casbin', async () => {
         const enforcer = new Enforcer('http://localhost:4000/api/casbin?casbin_subject=alice');
-        await enforcer.getData();
+        const respData = await enforcer.getData();
+        const data = JSON.parse(respData);
+        expect(data).toMatchObject({
+            read: ['data1', 'data2'],
+            write: ['data2']
+        })
     });
 
     afterAll(() => server.terminate());

--- a/src/__test__/server.test.ts
+++ b/src/__test__/server.test.ts
@@ -4,6 +4,7 @@
 
 import { Enforcer } from '../index';
 import TestServer from './server';
+import Axios from 'axios';
 
 describe('Communication with server', () => {
     let server: TestServer;
@@ -12,17 +13,10 @@ describe('Communication with server', () => {
         await server.start();
     });
 
-    test('Get data from server', async () => {
-        const enforcer = new Enforcer('http://localhost:4000');
-        const data = await enforcer.getData();
-        expect(data).toBe('this is the data');
-    });
-
     test('Request for /api/casbin', async () => {
-        const enforcer = new Enforcer('http://localhost:4000/api/casbin?casbin_subject=alice');
-        const respData = await enforcer.getData();
-        const data = JSON.parse(respData);
-        expect(data).toMatchObject({
+        const enforcer = new Enforcer('http://localhost:4000/api/casbin');
+        await enforcer.setUser('alice');
+        expect(enforcer.getProfiles()).toMatchObject({
             read: ['data1', 'data2'],
             write: ['data2']
         })

--- a/src/__test__/server.ts
+++ b/src/__test__/server.ts
@@ -1,32 +1,28 @@
-const express = require("express");
+const express = require('express');
 
 class TestServer {
-  private app: any;
-  private port = 4000;
-  private listener: any;
-  public constructor(port?: number) {
-    if (port) {
-      this.port = port;
+    private app: any;
+    private port = 4000;
+    private listener: any;
+    public constructor(port?: number) {
+        if (port) {
+            this.port = port;
+        }
     }
-  }
-  public start() {
-    this.app = express();
-    this.app.get("/", (req: any, res: any) => {
-      res.status(200).json({
-        message: "ok",
-        data: "this is the data",
-      });
-    });
-    this.listener = this.app.listen(this.port, () =>
-      console.log(
-        `Express server is listening at http://localhost:${this.port}`
-      )
-    );
-  }
-  public terminate() {
-    this.listener.close();
-    console.log("Express server is terminated");
-  }
+    public start() {
+        this.app = express();
+        this.app.get('/', (req: any, res: any) => {
+            res.status(200).json({
+                message: 'ok',
+                data: 'this is the data',
+            });
+        });
+        this.listener = this.app.listen(this.port, () => console.log(`Express server is listening at http://localhost:${this.port}`));
+    }
+    public terminate() {
+        this.listener.close();
+        console.log('Express server is terminated');
+    }
 }
 
 export default TestServer;

--- a/src/__test__/server.ts
+++ b/src/__test__/server.ts
@@ -2,23 +2,25 @@ import * as http from "http";
 import express from 'express';
 import { newEnforcer, Enforcer } from 'casbin';
 
-
 class CasbinService {
     private enforcer! : Enforcer;
     
     public async run() {
+        // RBAC API doesn't support RBAC w/ domain.
         // this.enforcer = await newEnforcer('./src/__test__/example/rbac_with_domains_model.conf', './src/__test__/example/rbac_with_domains_policy.csv');
         this.enforcer = await newEnforcer('./src/__test__/example/rbac_model.conf', './src/__test__/example/rbac_policy.csv');
     }
     
-    // TODO: Create an interface for getting all the policies
     public async getProfiles(sub: string) : Promise<string> {
         const policies = await this.enforcer.getImplicitPermissionsForUser(sub);
-        // policies.forEach(policy => {
-        //     policy[2]
-        // })
-        console.log(policies);
-        return "123";
+        let profiles : { [key:string]: string[] } = {};
+        policies.forEach(policy => {
+            if (!profiles.hasOwnProperty(policy[2])) {
+                profiles[policy[2]] = [];
+            }
+            profiles[policy[2]].push(policy[1]);
+        })
+        return JSON.stringify(profiles);
     }
 }
 

--- a/src/__test__/server.ts
+++ b/src/__test__/server.ts
@@ -1,25 +1,65 @@
-const express = require('express');
+import * as http from "http";
+import express from 'express';
+import { newEnforcer, Enforcer } from 'casbin';
+
+
+class CasbinService {
+    private enforcer! : Enforcer;
+    
+    public async run() {
+        // this.enforcer = await newEnforcer('./src/__test__/example/rbac_with_domains_model.conf', './src/__test__/example/rbac_with_domains_policy.csv');
+        this.enforcer = await newEnforcer('./src/__test__/example/rbac_model.conf', './src/__test__/example/rbac_policy.csv');
+    }
+    
+    // TODO: Create an interface for getting all the policies
+    public async getProfiles(sub: string) : Promise<string> {
+        const policies = await this.enforcer.getImplicitPermissionsForUser(sub);
+        // policies.forEach(policy => {
+        //     policy[2]
+        // })
+        console.log(policies);
+        return "123";
+    }
+}
 
 class TestServer {
-    private app: any;
+    private app: express.Application;
     private port = 4000;
-    private listener: any;
+    private listener!: http.Server;
+    private casbinServ: CasbinService;
     public constructor(port?: number) {
         if (port) {
             this.port = port;
         }
-    }
-    public start() {
         this.app = express();
-        this.app.get('/', (req: any, res: any) => {
+        this.casbinServ = new CasbinService();
+        
+    }
+
+    private async setRouter(): Promise<void> {
+        this.app.get('/', (req: express.Request, res: express.Response) => {
             res.status(200).json({
                 message: 'ok',
-                data: 'this is the data',
-            });
+                data: 'this is the data'
+            })
         });
+        this.app.get('/api/casbin', async (req: express.Request, res: express.Response) => {
+            const sub = String(req.query["casbin_subject"]);
+            const policies = await this.casbinServ.getProfiles(sub);
+            res.status(200).json({
+                message: 'ok',
+                data: policies
+            })
+        })
+    }
+
+    public async start() : Promise<void> {
+        await this.casbinServ.run();
+        await this.setRouter();
         this.listener = this.app.listen(this.port, () => console.log(`Express server is listening at http://localhost:${this.port}`));
     }
-    public terminate() {
+
+    public async terminate() : Promise<void> {
         this.listener.close();
         console.log('Express server is terminated');
     }

--- a/src/__test__/server.ts
+++ b/src/__test__/server.ts
@@ -1,0 +1,32 @@
+const express = require("express");
+
+class TestServer {
+  private app: any;
+  private port = 4000;
+  private listener: any;
+  public constructor(port?: number) {
+    if (port) {
+      this.port = port;
+    }
+  }
+  public start() {
+    this.app = express();
+    this.app.get("/", (req: any, res: any) => {
+      res.status(200).json({
+        message: "ok",
+        data: "this is the data",
+      });
+    });
+    this.listener = this.app.listen(this.port, () =>
+      console.log(
+        `Express server is listening at http://localhost:${this.port}`
+      )
+    );
+  }
+  public terminate() {
+    this.listener.close();
+    console.log("Express server is terminated");
+  }
+}
+
+export default TestServer;

--- a/src/__test__/server.ts
+++ b/src/__test__/server.ts
@@ -13,9 +13,9 @@ class CasbinService {
     
     public async getProfiles(sub: string) : Promise<string> {
         const policies = await this.enforcer.getImplicitPermissionsForUser(sub);
-        let profiles : { [key:string]: string[] } = {};
+        const profiles : { [key:string]: string[] } = {};
         policies.forEach(policy => {
-            if (!profiles.hasOwnProperty(policy[2])) {
+            if (!(policy[2] in profiles)) {
                 profiles[policy[2]] = [];
             }
             profiles[policy[2]].push(policy[1]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,34 +1,34 @@
-import axios from "axios";
+import axios from 'axios';
 
 interface BaseResponse {
-  message: string;
-  data: any;
+    message: string;
+    data: any;
 }
 
 export class Enforcer {
-  private profiles = '';
-  private endpoint: string;
+    private profiles = '';
+    private endpoint: string;
 
-  constructor(endpoint: string) {
-    this.endpoint = endpoint;
-  }
+    constructor(endpoint: string) {
+        this.endpoint = endpoint;
+    }
 
-  /**
-   * Get the authority of a given user from Casbin core
-   */
-  private async getUserProfiles(user: string): Promise<void> {
-    throw new Error("Not implemented");
-  }
+    /**
+     * Get the authority of a given user from Casbin core
+     */
+    private async getUserProfiles(user: string): Promise<void> {
+        throw new Error('Not implemented');
+    }
 
-  /**
-   * To enforce if the user have the authority to perform `act` on `obj`
-   */
-  public async enforce(obj: string, act: string): Promise<void> {
-    throw new Error("Not implemented");
-  }
+    /**
+     * To enforce if the user have the authority to perform `act` on `obj`
+     */
+    public async enforce(obj: string, act: string): Promise<void> {
+        throw new Error('Not implemented');
+    }
 
-  public async getData(): Promise<any> {
-    const resp = await axios.get<BaseResponse>(this.endpoint);
-    return resp.data.data;
-  }
+    public async getData(): Promise<any> {
+        const resp = await axios.get<BaseResponse>(this.endpoint);
+        return resp.data.data;
+    }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,34 @@
+import axios from "axios";
+
+interface BaseResponse {
+  message: string;
+  data: any;
+}
+
+export class Enforcer {
+  private profiles = '';
+  private endpoint: string;
+
+  constructor(endpoint: string) {
+    this.endpoint = endpoint;
+  }
+
+  /**
+   * Get the authority of a given user from Casbin core
+   */
+  private async getUserProfiles(user: string): Promise<void> {
+    throw new Error("Not implemented");
+  }
+
+  /**
+   * To enforce if the user have the authority to perform `act` on `obj`
+   */
+  public async enforce(obj: string, act: string): Promise<void> {
+    throw new Error("Not implemented");
+  }
+
+  public async getData(): Promise<any> {
+    const resp = await axios.get<BaseResponse>(this.endpoint);
+    return resp.data.data;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,18 +6,40 @@ interface BaseResponse {
 }
 
 export class Enforcer {
-    private profiles = '';
     private endpoint: string;
+    private user : string | undefined;
+    private profiles: {[key: string]: string[]} = {};
 
-    constructor(endpoint: string) {
+    public constructor(endpoint: string) {
         this.endpoint = endpoint;
+    }
+
+    /**
+     * Get the profiles.
+     */
+    public getProfiles() : {[key: string]: string[]} {
+        return this.profiles;
     }
 
     /**
      * Get the authority of a given user from Casbin core
      */
-    private async getUserProfiles(user: string): Promise<void> {
-        throw new Error('Not implemented');
+    public async syncUserProfiles(): Promise<void> {
+        const resp = await axios.get<BaseResponse>(`${this.endpoint}?casbin_subject=${this.user}`);
+        this.profiles = JSON.parse(resp.data.data);
+        console.log("syncUserProfiles is called")
+    }
+
+    /**
+     * Set the user subject for the enforcer
+     * @param user The current user
+     */
+    public async setUser(user : string) : Promise<void> {
+        // Sync with the server and fetch the latest profiles of the new user
+        if (user != this.user) {
+            this.user = user;
+            await this.syncUserProfiles()
+        }        
     }
 
     /**
@@ -27,8 +49,4 @@ export class Enforcer {
         throw new Error('Not implemented');
     }
 
-    public async getData(): Promise<any> {
-        const resp = await axios.get<BaseResponse>(this.endpoint);
-        return resp.data.data;
-    }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,71 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "lib": ["es6"],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./lib",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+  },
+  "include": ["./src", "src/__test__/.test.ts"],
+  "exclude": ["node_modules", "**/__test__/*"]
+}


### PR DESCRIPTION
I've created some basic api for casbin.js enforcer, which is used for syncing the user profiles.

1. `setUser` to set the current subject identity. When it is called, casbin.js enforcer will verify if the subject is modified and if there comes a new subject, it will try to sync with the backend server (call the `syncUserProfiles`)
2. `syncUserProfiles` to fetch subject profiles and save it at the frontend. 
3. `getProfiles` to get the user profiles.