### PR TITLE
feat: Multiple sections type

### DIFF
--- a/examples/mulitple_policy.csv
+++ b/examples/mulitple_policy.csv
@@ -1,0 +1,2 @@
+p2, alice, data1, read
+p2, bob, data2, write

--- a/src/coreEnforcer.ts
+++ b/src/coreEnforcer.ts
@@ -18,6 +18,8 @@ import { DefaultEffector, Effect, Effector } from './effect';
 import { FunctionMap, Model, newModel, PolicyOp } from './model';
 import { Adapter, FilteredAdapter, Watcher } from './persist';
 import { DefaultRoleManager, RoleManager } from './rbac';
+import { EnforceContext } from './enforceContext';
+
 import {
   escapeAssertion,
   generateGFunction,
@@ -47,6 +49,7 @@ export class CoreEnforcer {
   protected fm: FunctionMap = FunctionMap.loadFunctionMap();
   protected eft: Effector = new DefaultEffector();
   private matcherMap: Map<string, Matcher> = new Map();
+  private defaultEnforceContext: EnforceContext = new EnforceContext('r', 'p', 'e', 'm');
 
   protected adapter: Adapter;
   protected watcher: Watcher | null = null;
@@ -392,7 +395,12 @@ export class CoreEnforcer {
     }
   }
 
-  private *privateEnforce(asyncCompile = true, explain = false, ...rvals: any[]): EnforceResult {
+  private *privateEnforce(
+    asyncCompile = true,
+    explain = false,
+    enforceContext: EnforceContext = new EnforceContext('r', 'p', 'e', 'm'),
+    ...rvals: any[]
+  ): EnforceResult {
     if (!this.enabled) {
       return true;
     }
@@ -411,12 +419,12 @@ export class CoreEnforcer {
       functions[key] = isRoleManagerSync(rm) ? generateSyncGFunction(rm) : generateGFunction(rm);
     });
 
-    const expString = this.model.model.get('m')?.get('m')?.value;
+    const expString = this.model.model.get('m')?.get(enforceContext.mType)?.value;
     if (!expString) {
       throw new Error('Unable to find matchers in model');
     }
 
-    const effectExpr = this.model.model.get('e')?.get('e')?.value;
+    const effectExpr = this.model.model.get('e')?.get(enforceContext.eType)?.value;
     if (!effectExpr) {
       throw new Error('Unable to find policy_effect in model');
     }
@@ -424,10 +432,10 @@ export class CoreEnforcer {
     const HasEval: boolean = hasEval(expString);
     let expression: Matcher | undefined = undefined;
 
-    const p = this.model.model.get('p')?.get('p');
+    const p = this.model.model.get('p')?.get(enforceContext.pType);
     const policyLen = p?.policy?.length;
 
-    const rTokens = this.model.model.get('r')?.get('r')?.tokens;
+    const rTokens = this.model.model.get('r')?.get(enforceContext.rType)?.tokens;
     const rTokensLen = rTokens?.length;
 
     const effectStream = this.eft.newStream(effectExpr);
@@ -565,7 +573,11 @@ export class CoreEnforcer {
    * @return whether to allow the request.
    */
   public enforceSync(...rvals: any[]): boolean {
-    return generatorRunSync(this.privateEnforce(false, false, ...rvals));
+    if (rvals[0] instanceof EnforceContext) {
+      const enforceContext: EnforceContext = rvals.shift();
+      return generatorRunSync(this.privateEnforce(false, false, enforceContext, ...rvals));
+    }
+    return generatorRunSync(this.privateEnforce(false, false, this.defaultEnforceContext, ...rvals));
   }
 
   /**
@@ -579,7 +591,11 @@ export class CoreEnforcer {
    * @return whether to allow the request and the reason rule.
    */
   public enforceExSync(...rvals: any[]): [boolean, string[]] {
-    return generatorRunSync(this.privateEnforce(false, true, ...rvals));
+    if (rvals[0] instanceof EnforceContext) {
+      const enforceContext: EnforceContext = rvals.shift();
+      return generatorRunSync(this.privateEnforce(false, true, enforceContext, ...rvals));
+    }
+    return generatorRunSync(this.privateEnforce(false, true, this.defaultEnforceContext, ...rvals));
   }
 
   /**
@@ -598,7 +614,11 @@ export class CoreEnforcer {
    * @return whether to allow the request.
    */
   public async enforce(...rvals: any[]): Promise<boolean> {
-    return generatorRunAsync(this.privateEnforce(true, false, ...rvals));
+    if (rvals[0] instanceof EnforceContext) {
+      const enforceContext: EnforceContext = rvals.shift();
+      return generatorRunAsync(this.privateEnforce(true, false, enforceContext, ...rvals));
+    }
+    return generatorRunAsync(this.privateEnforce(true, false, this.defaultEnforceContext, ...rvals));
   }
 
   /**
@@ -610,6 +630,10 @@ export class CoreEnforcer {
    * @return whether to allow the request and the reason rule.
    */
   public async enforceEx(...rvals: any[]): Promise<[boolean, string[]]> {
-    return generatorRunAsync(this.privateEnforce(true, true, ...rvals));
+    if (rvals[0] instanceof EnforceContext) {
+      const enforceContext: EnforceContext = rvals.shift();
+      return generatorRunAsync(this.privateEnforce(true, true, enforceContext, ...rvals));
+    }
+    return generatorRunAsync(this.privateEnforce(true, true, this.defaultEnforceContext, ...rvals));
   }
 }

--- a/src/enforceContext.ts
+++ b/src/enforceContext.ts
@@ -1,0 +1,20 @@
+import { newEnforcer } from './enforcer';
+
+export class EnforceContext {
+  public pType: string;
+  public rType: string;
+  public eType: string;
+  public mType: string;
+
+  constructor(rType: string, pType: string, eType: string, mType: string) {
+    this.pType = pType;
+    this.eType = eType;
+    this.mType = mType;
+    this.rType = rType;
+  }
+}
+export class NewEnforceContext {
+  constructor(index: string) {
+    return new EnforceContext('r' + index, 'p' + index, 'e' + index, 'm' + index);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,4 +23,5 @@ export * from './model';
 export * from './persist';
 export * from './rbac';
 export * from './log';
+export { EnforceContext } from './enforceContext';
 export { Util };

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -18,9 +18,9 @@
 import { RoleManager } from '../rbac';
 
 function escapeAssertion(s: string): string {
-  s = s.replace(/r\./g, 'r_');
-  s = s.replace(/p\./g, 'p_');
-  return s;
+  return s.replace(/([rp])\.|[0-9]\./g, (match) => {
+    return match.replace('.', '_');
+  });
 }
 
 // removeComments removes the comments starting with # in the text.

--- a/test/enforcer.test.ts
+++ b/test/enforcer.test.ts
@@ -14,6 +14,7 @@
 
 import { readFileSync } from 'fs';
 
+import { NewEnforceContext, EnforceContext } from '../src/enforceContext';
 import { newModel, newEnforcer, Enforcer, MemoryAdapter, Util } from '../src';
 import { getEnforcerWithPath, getStringAdapter } from './utils';
 
@@ -628,4 +629,71 @@ test('test ABAC multiple eval()', async () => {
   await testEnforce(e, 56, (98 as unknown) as string, 'read', true);
   await testEnforce(e, 23, (67 as unknown) as string, 'read', false);
   await testEnforce(e, 78, (34 as unknown) as string, 'read', false);
+});
+
+test('TestEnforce Multiple policies config', async () => {
+  const m = newModel();
+  m.addDef('r', 'r2', 'sub, obj, act');
+  m.addDef('p', 'p2', 'sub, obj, act');
+  m.addDef('g', 'g', '_, _');
+  m.addDef('e', 'e2', 'some(where (p.eft == allow))');
+  m.addDef('m', 'm2', 'g(r2.sub, p2.sub) && r2.obj == p2.obj && r2.act == p2.act');
+  const a = getStringAdapter('examples/mulitple_policy.csv');
+
+  const e = await newEnforcer(m, a);
+
+  //const e = await getEnforcerWithPath(m);
+  const enforceContext = new EnforceContext('r2', 'p2', 'e2', 'm2');
+  await expect(e.enforce(enforceContext, 'alice', 'data1', 'read')).resolves.toStrictEqual(true);
+  await expect(e.enforce(enforceContext, 'bob', 'data2', 'write')).resolves.toStrictEqual(true);
+});
+test('new EnforceContext config', async () => {
+  const m = newModel();
+  m.addDef('r', 'r2', 'sub, obj, act');
+  m.addDef('p', 'p2', 'sub, obj, act');
+  m.addDef('g', 'g', '_, _');
+  m.addDef('e', 'e2', 'some(where (p.eft == allow))');
+  m.addDef('m', 'm2', 'g(r2.sub, p2.sub) && r2.obj == p2.obj && r2.act == p2.act');
+  const a = getStringAdapter('examples/mulitple_policy.csv');
+
+  const e = await newEnforcer(m, a);
+
+  //const e = await getEnforcerWithPath(m);
+  const enforceContext = new NewEnforceContext('2');
+  await expect(e.enforce(enforceContext, 'alice', 'data1', 'read')).resolves.toStrictEqual(true);
+  await expect(e.enforce(enforceContext, 'bob', 'data2', 'write')).resolves.toStrictEqual(true);
+});
+
+test('TestEnforceEX Multiple policies config', async () => {
+  const m = newModel();
+  m.addDef('r', 'r2', 'sub, obj, act');
+  m.addDef('p', 'p2', 'sub, obj, act');
+  m.addDef('g', 'g', '_, _');
+  m.addDef('e', 'e2', 'some(where (p.eft == allow))');
+  m.addDef('m', 'm2', 'g(r2.sub, p2.sub) && r2.obj == p2.obj && r2.act == p2.act');
+  const a = getStringAdapter('examples/mulitple_policy.csv');
+
+  const e = await newEnforcer(m, a);
+
+  //const e = await getEnforcerWithPath(m);
+  const enforceContext = new EnforceContext('r2', 'p2', 'e2', 'm2');
+  await expect(e.enforceEx(enforceContext, 'alice', 'data1', 'read')).resolves.toStrictEqual([true, ['alice', 'data1', 'read']]);
+  await expect(e.enforceEx(enforceContext, 'bob', 'data2', 'write')).resolves.toStrictEqual([true, ['bob', 'data2', 'write']]);
+});
+
+test('new EnforceContextEX config', async () => {
+  const m = newModel();
+  m.addDef('r', 'r2', 'sub, obj, act');
+  m.addDef('p', 'p2', 'sub, obj, act');
+  m.addDef('g', 'g', '_, _');
+  m.addDef('e', 'e2', 'some(where (p.eft == allow))');
+  m.addDef('m', 'm2', 'g(r2.sub, p2.sub) && r2.obj == p2.obj && r2.act == p2.act');
+  const a = getStringAdapter('examples/mulitple_policy.csv');
+
+  const e = await newEnforcer(m, a);
+
+  //const e = await getEnforcerWithPath(m);
+  const enforceContext = new NewEnforceContext('2');
+  await expect(e.enforceEx(enforceContext, 'alice', 'data1', 'read')).resolves.toStrictEqual([true, ['alice', 'data1', 'read']]);
+  await expect(e.enforceEx(enforceContext, 'bob', 'data2', 'write')).resolves.toStrictEqual([true, ['bob', 'data2', 'write']]);
 });


### PR DESCRIPTION
1.configure it with multiple policies
2.Add relevant unit tests
3.fix the regular matching problem of RABC
4.Make regular matching more accurate and flexible
If you need multiple policy definitions or multiple matcher, you can use like p2, m2. In fact, all of the above four sections can use multiple types and the syntax is r+number, such as r2, e2. By default these four sections should correspond one to one. Such as your r2 will only use matcher m2 to match policies p2.

const enforceContext = new EnforceContext('r2', 'p2', 'e2', 'm2');
or
const enforceContext = new NewEnforceContext('2');