### PR TITLE
feat: Extend multiple sections type of escapeAssertion

### DIFF
--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -18,7 +18,10 @@
 import { RoleManager } from '../rbac';
 
 function escapeAssertion(s: string): string {
-  return s.replace(/([rp])\.|[0-9]\./g, (match) => {
+  if (s.startsWith('r') || s.startsWith('p')) {
+    s = s.replace('.', '_');
+  }
+  return s.replace(/([| =)(&<>,+\-!*\/])([rp][0-9]*)\./g, (match) => {
     return match.replace('.', '_');
   });
 }

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -190,3 +190,19 @@ test('test keyGet2Func', () => {
   expect(util.keyGet2Func('/baz', '/foo', 'bar')).toEqual('');
   expect(util.keyGet2Func('/foo/baz', '/foo', 'bar')).toEqual('');
 });
+
+test('test escapeAssertion', () => {
+  expect(util.escapeAssertion('r.attr.value == p.attr')).toEqual('r_attr.value == p_attr');
+  expect(util.escapeAssertion('r.attp.value || p.attr')).toEqual('r_attp.value || p_attr');
+  expect(util.escapeAssertion('r.attp.value && p.attr')).toEqual('r_attp.value && p_attr');
+  expect(util.escapeAssertion('r.attp.value >p.attr')).toEqual('r_attp.value >p_attr');
+  expect(util.escapeAssertion('r.attp.value <p.attr')).toEqual('r_attp.value <p_attr');
+  expect(util.escapeAssertion('r.attp.value +p.attr')).toEqual('r_attp.value +p_attr');
+  expect(util.escapeAssertion('r.attp.value -p.attr')).toEqual('r_attp.value -p_attr');
+  expect(util.escapeAssertion('r.attp.value *p.attr')).toEqual('r_attp.value *p_attr');
+  expect(util.escapeAssertion('r.attp.value /p.attr')).toEqual('r_attp.value /p_attr');
+  expect(util.escapeAssertion('!r.attp.value /p.attr')).toEqual('!r_attp.value /p_attr');
+  expect(util.escapeAssertion('g(r.sub, p.sub) == p.attr')).toEqual('g(r_sub, p_sub) == p_attr');
+  expect(util.escapeAssertion('g(r.sub,p.sub) == p.attr')).toEqual('g(r_sub,p_sub) == p_attr');
+  expect(util.escapeAssertion('(r.attp.value || p.attr)p.u')).toEqual('(r_attp.value || p_attr)p_u');
+});

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -205,4 +205,6 @@ test('test escapeAssertion', () => {
   expect(util.escapeAssertion('g(r.sub, p.sub) == p.attr')).toEqual('g(r_sub, p_sub) == p_attr');
   expect(util.escapeAssertion('g(r.sub,p.sub) == p.attr')).toEqual('g(r_sub,p_sub) == p_attr');
   expect(util.escapeAssertion('(r.attp.value || p.attr)p.u')).toEqual('(r_attp.value || p_attr)p_u');
+  expect(util.escapeAssertion('r1.value == p1.value')).toEqual('r1_value == p1_value');
+  expect(util.escapeAssertion('r2.value == p4.value')).toEqual('r2_value == p4_value');
 });


### PR DESCRIPTION
At present, only p < int > is supported. We should consider more forms. For example, consider supporting P < string > to meet the following test cases
r.attr.value == p.attr
r.attp.value || p.attr
r.attp.value && p.attr
r.attp.value >p.attr
r.attp.value <p.attr
r.attp.value +p.attr
r.attp.value -p.attr
r.attp.value *p.attr
r.attp.value /p.attr
!r.attp.value /p.attr'
g(r.sub, p.sub) == p.attr
g(r.sub,p.sub) == p.attr
(r.attp.value || p.attr)p.u