### PR TITLE
feat: implement custom Jest environment with native Fetch API and update tests to use fetch

### DIFF
--- a/jest.environment.js
+++ b/jest.environment.js
@@ -1,0 +1,24 @@
+// Custom jest environment that extends jsdom and injects the Node.js 18+
+// native Fetch API into the jsdom window. jsdom 20 (used by jest-environment-jsdom 29)
+// does not include fetch, but Node.js 18+ has it as a built-in global.
+// This file intentionally uses CommonJS and plain JS so that jest can load it
+// directly without going through a TypeScript transformation pipeline.
+
+const JsDOMEnvironment = require('jest-environment-jsdom').default;
+
+class FetchEnvironment extends JsDOMEnvironment {
+    async setup() {
+        await super.setup();
+        // Inject the Node.js native Fetch API into the jsdom window object.
+        // `fetch`, `Headers`, `Request` and `Response` are true globals in Node.js 18+,
+        // so they are accessible here in the Node.js module scope.
+        if (!this.global.fetch) {
+            this.global.fetch = fetch;
+            this.global.Headers = Headers;
+            this.global.Request = Request;
+            this.global.Response = Response;
+        }
+    }
+}
+
+module.exports = FetchEnvironment;

--- a/jestconfig.json
+++ b/jestconfig.json
@@ -2,7 +2,7 @@
     "transform": {
         "^.+\\.(t|j)sx?$": "ts-jest"
     },
-    "testEnvironment": "jsdom",
+    "testEnvironment": "./jest.environment.js",
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"],
     "coveragePathIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   "dependencies": {
     "@babel/core": "^7.14.6",
     "@babel/preset-env": "^7.14.5",
-    "axios": "^0.21.1",
     "babel-loader": ">=8.1.0",
     "casbin-core": "^0.0.0-beta.2",
     "js-cookie": "^2.2.1"

--- a/src/Authorizer.ts
+++ b/src/Authorizer.ts
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import * as casbin from 'casbin-core';
 import Permission from './Permission';
 import { StringKV } from './types';
@@ -107,14 +106,18 @@ export class Authorizer {
     /**
      * Initialize the enforcer
      */
-    public async getEnforcerDataFromSvr(): Promise<string>{
+    public async getEnforcerDataFromSvr(): Promise<string> {
         if (this.endpoint === undefined || this.endpoint === null) {
-            throw Error("Endpoint is null or not specified.");
+            throw Error('Endpoint is null or not specified.');
         }
-        const resp = await axios.get<BaseResponse>(`${this.endpoint}?subject=${this.user}`, {
-            headers: this.requestHeaders,
+        const resp = await fetch(`${this.endpoint}?subject=${this.user}`, {
+            headers: this.requestHeaders as unknown as HeadersInit,
         });
-        return resp.data.data;
+        if (!resp.ok) {
+            throw new Error(`Request failed with status ${resp.status}`);
+        }
+        const body: BaseResponse = await resp.json();
+        return body.data;
     }
 
     /**

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -1,27 +1,24 @@
-import axios from 'axios';
 import { Authorizer } from '../index';
 import { basicModelStr } from './models';
 import { basicPolicies } from './policies';
 import { removeLocalStorage } from '../Cache';
 import TestServer  from './server';
 
-jest.mock('axios');
-const mockedAxios = axios as jest.Mocked<typeof axios>;
-
 test('Mock functions', () => {
     const respObj = {
         m: basicModelStr,
-        p: basicPolicies
-    }
-    const resp = { data: { message: 'ok', data: JSON.stringify(respObj)}};
-    // Specify the returned data of the mockedAxios once
-    mockedAxios.get.mockImplementationOnce(() => Promise.resolve(resp));
+        p: basicPolicies,
+    };
+    const mockResponse = { message: 'ok', data: JSON.stringify(respObj) };
+    const mockFetch = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+    } as Response);
     // TODO: Use mock function to get response object
     // const authorizer = new Authorizer('http://localhost:4000');
     // authorizer.setUser('alice');
     // expect(authorizer.getPermission()).toMatchObject(respObj);
-
-    // expect(mockedAxios.get('http://localhost:4000/api/permissions?subject=alice')).toMatchObject(respObj);
+    mockFetch.mockRestore();
 });
 
 async function check(authorizer: Authorizer) {

--- a/src/__test__/server.ts
+++ b/src/__test__/server.ts
@@ -11,6 +11,13 @@ class CasbinService {
         // RBAC API doesn't support RBAC w/ domain.
         // this.enforcer = await newEnforcer('./src/__test__/example/rbac_with_domains_model.conf', './src/__test__/example/rbac_with_domains_policy.csv');
         this.enforcer = await newEnforcer(new Model(basicModelStr));
+        // These policies mirror basicPolicies from policies.ts, which the integration test's
+        // check() helper expects. Previously this was never reached because jest.mock('axios')
+        // intercepted all HTTP calls before they hit the server. Now that auto mode uses native
+        // fetch, the test makes a real HTTP request, so the server must have policies loaded.
+        await this.enforcer.addPolicy('alice', 'data1', 'read');
+        await this.enforcer.addPolicy('alice', 'data2', 'read');
+        await this.enforcer.addPolicy('alice', 'data2', 'write');
     }
     
     public async getEnforcerConfig(sub: string): Promise<string> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2099,13 +2099,6 @@ await-lock@^2.0.1:
   resolved "https://registry.yarnpkg.com/await-lock/-/await-lock-2.2.2.tgz#a95a9b269bfd2f69d22b17a321686f551152bcef"
   integrity sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==
 
-axios@^0.21.1:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
-  dependencies:
-    follow-redirects "^1.14.0"
-
 babel-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.7.0.tgz#f4369919225b684c56085998ac63dbd05be020d5"
@@ -3802,7 +3795,7 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
   integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.0:
+follow-redirects@^1.0.0:
   version "1.15.11"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
   integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==


### PR DESCRIPTION
fix: https://github.com/apache/casbin-casbin.js/issues/314

It replaces the use of `axios` with the native Fetch API throughout the codebase, updates the Jest test environment to support Fetch, and adjusts tests and server setup accordingly. The changes modernize HTTP requests and streamline dependencies, ensuring compatibility with Node.js 18+.
